### PR TITLE
feat(fix: getPort)

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -25,10 +25,10 @@ function setup (options) {
 /**
  * Checks if there is a setup port or tries to find one.
  * @param  {Number}   port     Desired port
- * @return {Number|Promise}
+ * @return {Promise}
  */
 function getPort (port) {
-  return port || parseInt(process.env.PORT, 10) || findPort()
+  return port ? Promise.resolve(port) : findPort()
 }
 
 /**


### PR DESCRIPTION
Fix error when option -p is passed,
setup expect always a promise, so it fails when port is a number:

exprexo -d routes/ -p 3000
exprexo and javascript make the perfect blend
/home/user/.nvm/versions/node/v6.3.0/lib/node_modules/exprexo/lib/cli/index.js:12
    .then(updateOptions)
     ^

TypeError: getPort(...).then is not a function
    at setup (/home/user/.nvm/versions/node/v6.3.0/lib/node_modules/exprexo/lib/cli/index.js:12:6)
    at Object.<anonymous> (/home/user/.nvm/versions/node/v6.3.0/lib/node_modules/exprexo/bin/exprexo:16:1)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)