### PR TITLE
feat: Add parsers as a default.

### DIFF
--- a/lib/exprexo.js
+++ b/lib/exprexo.js
@@ -12,6 +12,10 @@ function createServer (options, callback) {
   const app = express()
 
   app.use(cors())
+  // For parsing `application/json`.
+  app.use(express.json())
+  // For parsing `application/x-www-form-urlencoded`.
+  app.use(express.urlencoded({ extended: true }))
 
   // TODO morgan as verbose?
   // app.use(logger('dev'))


### PR DESCRIPTION
* Add parser middleware for parsing `application/json`.
 * Add parser middleware for parsing `application/x-www-form-urlencoded`.

BREAKING CHANGE: `req.body` will not longer be `undefined`,
 will include a parsed json instead with the request payload.

---

Lacking tests 😅 