### PR TITLE
chore: Add missing semantic-release config

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "yargs": "^6.3.0"
   },
   "devDependencies": {
+    "@jedmao/semantic-release-npm-github-config": "^1.0.6",
     "decache": "^4.1.0",
     "faucet": "0.0.1",
     "generate-changelog": "^1.0.2",


### PR DESCRIPTION
* Add `@jedmao/semantic-release-npm-github-config`
 to `package.json` devDependencies.