### PR TITLE
Feat/watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Usage: exprexo [path] [options]
 Mode
   --silent, -s  Make this exprexo in silence          [boolean] [default: false]
   --verbose     Make this exprexo loud as hell        [boolean] [default: false]
+  --watch, -w   Make this exprexo double charge an    [boolean] [default: false]
+                checking your directory for changes 
 
 Options:
   --directory, -d  A cool directory to be served           [default: "./routes"]

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -35,6 +35,14 @@ const argv = yargs.detectLocale(false)
     default: false,
     group: 'mode'
   })
+  .option('watch', {
+    describe: 'Make exprexo double exprexo to catch any change in your api',
+    alias: 'w',
+    demand: false,
+    boolean: true,
+    default: false,
+    group: 'mode'
+  })
   .help()
   .version()
   .epilogue(`For more information, find exprexo at ${pkg.homepage}`)
@@ -44,7 +52,8 @@ const options = Object.assign(
   {},
   argv,
   {
-    directory: argv._[0] || argv.directory
+    directory: argv._[0] || argv.directory,
+    watch: argv.watch
   })
 
 module.exports = options

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -12,13 +12,14 @@ function setup (options = {}) {
     .then(updateOptions)
 
   function updateOptions (port) {
-    const { directory, open, silent, verbose } = options
+    const {directory, open, silent, verbose, watch} = options
     return {
       directory,
       open,
       port,
       silent,
-      verbose
+      verbose,
+      watch
     }
   }
 }

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -12,7 +12,7 @@ function setup (options = {}) {
     .then(updateOptions)
 
   function updateOptions (port) {
-    const {directory, open, silent, verbose, watch} = options
+    const { directory, open, silent, verbose, watch } = options
     return {
       directory,
       open,

--- a/lib/exprexo.js
+++ b/lib/exprexo.js
@@ -1,7 +1,9 @@
-const router = require('./router')
 const express = require('express')
 const cors = require('cors')
+const { watcher } = require('pit-require-cache')
 
+const router = require('./router')
+const logger = require('../lib/logger')()
 /**
  * Creates a new server with the given options.
  * @param  {Object}   options  configurable options.
@@ -16,6 +18,11 @@ function createServer (options, callback) {
   app.use(express.json())
   // For parsing `application/x-www-form-urlencoded`.
   app.use(express.urlencoded({ extended: true }))
+
+  if (options.watch) {
+    watcher({directory: options.directory})
+    logger.info(`Exprexo running on watch mode`)
+  }
 
   // TODO morgan as verbose?
   // app.use(logger('dev'))

--- a/lib/exprexo.js
+++ b/lib/exprexo.js
@@ -20,7 +20,7 @@ function createServer (options, callback) {
   app.use(express.urlencoded({ extended: true }))
 
   if (options.watch) {
-    watcher({directory: options.directory})
+    watcher({ directory: options.directory })
     logger.info(`Exprexo running on watch mode`)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1025,12 +1025,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
-    "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-      "dev": true
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -1378,7 +1372,8 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "compare-func": {
       "version": "1.3.2",
@@ -3489,17 +3484,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "generate-changelog": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/generate-changelog/-/generate-changelog-1.8.0.tgz",
-      "integrity": "sha512-msgpxeB75Ziyg3wGsZuPNl7c5RxChMKmYcAX5obnhUow90dBZW3nLic6nxGtst7Bpx453oS6zAIHcX7F3QVasw==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.0.6",
-        "commander": "^2.9.0",
-        "github-url-from-git": "^1.4.0"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -3520,12 +3504,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-    },
-    "github-url-from-git": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-      "dev": true
     },
     "glob": {
       "version": "5.0.15",
@@ -9322,8 +9300,7 @@
     "picomatch": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
-      "dev": true
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
     },
     "pify": {
       "version": "3.0.0",
@@ -9341,6 +9318,104 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
+      }
+    },
+    "pit-require-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pit-require-cache/-/pit-require-cache-1.0.0.tgz",
+      "integrity": "sha512-gXgeDvoQuJKCFMz36RRjTkkeQ7iVBqdRTPfhpY/4rr58wkrfayQTALe+IfeiS//vnE3MArPSdlIwf9ifcvwjGQ==",
+      "requires": {
+        "chokidar": "^3.0.2"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.3.tgz",
+          "integrity": "sha512-c6IvoeBECQlMVuYUjSwimnhmztImpErfxJzWZhIQinIvQWoGOnB0dLIgifbPHQt5heS6mNlaZG16f06H3C8t1g==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
+          "integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+          "requires": {
+            "anymatch": "^3.0.1",
+            "braces": "^3.0.2",
+            "fsevents": "^2.0.6",
+            "glob-parent": "^5.0.0",
+            "is-binary-path": "^2.1.0",
+            "is-glob": "^4.0.1",
+            "normalize-path": "^3.0.0",
+            "readdirp": "^3.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+          "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+          "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "readdirp": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.1.tgz",
+          "integrity": "sha512-XXdSXZrQuvqoETj50+JAitxz1UPdt5dupjT6T5nVB+WvjMv2XKYj+s7hPeAVCXvmJrL36O4YYyWlIC3an2ePiQ==",
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "pkg-conf": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "express": "^4.14.0",
     "nodemon": "^1.11.0",
     "opener": "^1.4.2",
+    "pit-require-cache": "^1.0.0",
     "portfinder": "^1.0.9",
     "update-notifier": "^1.0.2",
     "yargs": "^6.3.0"

--- a/test/lib/cli/index.test.js
+++ b/test/lib/cli/index.test.js
@@ -13,6 +13,7 @@ test('cli: should return only the following options', (t) => {
     port: 9000,
     silent: false,
     verbose: false,
+    watch: false,
     foo: 'foo', // this one should be removed
     bar: 'bar', // this one should be removed
     biz: 'biz' // this one should be removed
@@ -22,7 +23,8 @@ test('cli: should return only the following options', (t) => {
     open: true,
     port: 9000,
     silent: false,
-    verbose: false
+    verbose: false,
+    watch: false
   }
 
   cli(desiredOptions)


### PR DESCRIPTION
chore(dependencies): Add `pit-require-cache` package.

feat(modes): Add wath mode.
 * Add `--watch` and `-w` as valid mode options.
 * Use `pit-require-cache` to delete require cache when file updated.

test(options): Update test for new set of options.

docs(readme): Update documentation. 
 * Add `--watch` and `-w` options for watch mode